### PR TITLE
Add release workflow and clean up marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -48,10 +48,7 @@
         "swift",
         "apple-platforms"
       ],
-      "source": "./",
-      "skills": [
-        "./core-data-expert"
-      ]
+      "source": "./"
     }
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 1.0.2)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate version input
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid version '$VERSION'. Expected format like 1.0.2."
+            exit 1
+          fi
+
+      - name: Fail if tag already exists
+        run: |
+          set -euo pipefail
+
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "Error: Tag $VERSION already exists. Refusing to re-release the same version."
+            exit 1
+          fi
+
+      - name: Fail if version is not higher than latest release
+        run: |
+          set -euo pipefail
+
+          latest_tag="$(git tag -l '[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1)"
+          if [[ -z "$latest_tag" ]]; then
+            echo "No existing semver tags found. Proceeding with $VERSION."
+            exit 0
+          fi
+
+          latest_version="$latest_tag"
+
+          if [[ "$VERSION" == "$latest_version" ]]; then
+            echo "Error: Version $VERSION equals latest released version $latest_version. Use a higher version."
+            exit 1
+          fi
+
+          greatest="$(printf '%s\n%s\n' "$latest_version" "$VERSION" | sort -V | tail -n 1)"
+          if [[ "$greatest" != "$VERSION" ]]; then
+            echo "Error: Version $VERSION must be higher than latest released version $latest_version."
+            exit 1
+          fi
+
+      - name: Bump plugin.json version
+        run: |
+          set -euo pipefail
+
+          jq --arg v "$VERSION" '.version = $v' .claude-plugin/plugin.json > .claude-plugin/plugin.json.tmp
+          if [ -s .claude-plugin/plugin.json.tmp ]; then
+            mv .claude-plugin/plugin.json.tmp .claude-plugin/plugin.json
+          else
+            echo "Error: Failed to generate updated .claude-plugin/plugin.json"
+            exit 1
+          fi
+
+      - name: Bump marketplace.json versions
+        run: |
+          set -euo pipefail
+
+          jq --arg v "$VERSION" '.version = $v | .plugins[0].version = $v' .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp
+          if [ -s .claude-plugin/marketplace.json.tmp ]; then
+            mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
+          else
+            echo "Error: Failed to generate updated .claude-plugin/marketplace.json"
+            exit 1
+          fi
+
+      - name: Commit and push version bump
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet .claude-plugin/plugin.json .claude-plugin/marketplace.json; then
+            echo "Error: No changes detected after version bump. Is the repo already at version $VERSION?"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git commit -m "Bump version to $VERSION"
+          git push
+
+      - name: Create tag and GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,15 +97,14 @@ jobs:
           set -euo pipefail
 
           if git diff --quiet .claude-plugin/plugin.json .claude-plugin/marketplace.json; then
-            echo "Error: No changes detected after version bump. Is the repo already at version $VERSION?"
-            exit 1
+            echo "No changes detected — version files already at $VERSION (previous run may have pushed but not released). Skipping commit."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+            git commit -m "Bump version to $VERSION"
+            git push
           fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
-          git commit -m "Bump version to $VERSION"
-          git push
 
       - name: Create tag and GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` — a manually triggered workflow for creating semver releases (validates version, bumps plugin.json and marketplace.json, creates tag + GitHub Release with auto-generated notes). Ported from the [Swift-Concurrency-Agent-Skill](https://github.com/AvdLee/Swift-Concurrency-Agent-Skill) repo.
- Remove redundant `skills` array from `plugins[0]` in `.claude-plugin/marketplace.json` (already defined in `plugin.json`).

## Test plan
- [ ] Verify the release workflow appears in the Actions tab after merge
- [ ] Trigger a test release (e.g. `1.1.0`) via workflow_dispatch on main
- [ ] Confirm marketplace.json is valid JSON after the `skills` field removal